### PR TITLE
reload OIDC config every 24h

### DIFF
--- a/AAD.Giraffe/PartProtector.fs
+++ b/AAD.Giraffe/PartProtector.fs
@@ -96,6 +96,7 @@ module PartProtector =
                     return r
                 })
         
+            let! _ = getConfiguration() // prime the config cache
             let introspect = 
                 (TokenCache.mkDefault(), audiences, getConfiguration) |||> Introspector.mkNew 
             let project claim =
@@ -104,7 +105,6 @@ module PartProtector =
                     yield! ResourceOwner.ClaimProjection.ofRole claim
                     yield! ResourceOwner.ClaimProjection.ofScope claim
                 }
-            
             return mkNew introspect
                          (ResourceOwner.validate '/' project) 
                          audiences

--- a/AAD.Giraffe/ReadersAndWriters.fs
+++ b/AAD.Giraffe/ReadersAndWriters.fs
@@ -7,7 +7,7 @@ module Readers =
 
     let bearer (ctx: HttpContext) =
         ctx.TryGetRequestHeader "Authorization"
-        |> Option.map (String.split ' ') 
+        |> Option.map (String.trim >> String.split ' ') 
         |> Option.bind (function ["Bearer"; token] -> Some token | _ -> None)
 
     let bearerTokenString : HttpContext -> TokenString =

--- a/AAD.Suave/PartProtector.fs
+++ b/AAD.Suave/PartProtector.fs
@@ -4,6 +4,8 @@ open Suave
 open Suave.Operators
 open System.IdentityModel.Tokens.Jwt
 open Microsoft.IdentityModel.Protocols.OpenIdConnect
+open Microsoft.Extensions.Caching.Memory
+open FSharp.Control.Tasks.V2.ContextInsensitive
 
 /// PartProtector is the interface for a stateful protector instance.
 /// Use PartProtector module to create the instances implementing this interface.
@@ -42,12 +44,9 @@ module PartProtector =
     let mkNew (introspect: TokenString -> Async<Result<JwtSecurityToken,string>>)
               (validate: Demand -> JwtSecurityToken -> Result<JwtSecurityToken,string>)
               (audiences: #seq<Audience>)
-              (oidcConfig: OpenIdConnectConfiguration) =
+              (getConfig: unit -> Async<OpenIdConnectConfiguration>) =
         let resourceOwner =
-            ResourceOwner.mkNew introspect
-                                validate
-                                audiences
-                                oidcConfig
+            ResourceOwner.mkNew introspect validate audiences getConfig
                                                       
         { new PartProtector with 
             member __.Verify (getDemand: HttpContext -> Async<Demand>) 
@@ -84,12 +83,20 @@ module PartProtector =
                   (audiences: #seq<Audience>)
                   (authority: System.Uri) =
         async {
-            let! conf = OpenIdConnectConfigurationRetriever
-                            .GetAsync(sprintf "%O/.well-known/openid-configuration" authority, httpClient, System.Threading.CancellationToken.None)
-                        |> Async.AwaitTask                        
+            let getConfiguration =
+                let cache = new MemoryCache(new MemoryCacheOptions(SizeLimit = 1L)) 
+                fun () -> 
+                    cache.GetOrCreateAsync(1, fun e -> task {
+                        let! r = OpenIdConnectConfigurationRetriever
+                                    .GetAsync(sprintf "%O/.well-known/openid-configuration" authority, httpClient, System.Threading.CancellationToken.None)
+                                    .ConfigureAwait false
+                        e.SetAbsoluteExpiration (System.TimeSpan.FromHours 24.) |> ignore
+                        e.SetSize 1L |> ignore
+                        return r
+                    }) |> Async.AwaitTask
         
             let introspect = 
-                (TokenCache.mkDefault(), audiences, conf) |||> Introspector.mkNew 
+                (TokenCache.mkDefault(), audiences, getConfiguration) |||> Introspector.mkNew 
             let project claim =
                 seq {
                     yield! ResourceOwner.ClaimProjection.ofAppRole claim
@@ -100,5 +107,5 @@ module PartProtector =
             return mkNew introspect
                          (ResourceOwner.validate '/' project) 
                          audiences
-                         conf
+                         getConfiguration
         }

--- a/AAD.Suave/PartProtector.fs
+++ b/AAD.Suave/PartProtector.fs
@@ -95,6 +95,7 @@ module PartProtector =
                         return r
                     }) |> Async.AwaitTask
         
+            let! _ = getConfiguration() // prime the config cache
             let introspect = 
                 (TokenCache.mkDefault(), audiences, getConfiguration) |||> Introspector.mkNew 
             let project claim =
@@ -103,7 +104,6 @@ module PartProtector =
                     yield! ResourceOwner.ClaimProjection.ofRole claim
                     yield! ResourceOwner.ClaimProjection.ofScope claim
                 }
-
             return mkNew introspect
                          (ResourceOwner.validate '/' project) 
                          audiences

--- a/AAD.Suave/Readers.fs
+++ b/AAD.Suave/Readers.fs
@@ -12,7 +12,7 @@ module Readers =
 
     let bearer ctx =
         ctx.request.header "Authorization"
-        |> Choice.map (String.split ' ') 
+        |> Choice.map (String.trim >> String.split ' ') 
         |> Choice.bind (function ["Bearer"; token] -> Choice1Of2 token | _ -> Choice2Of2 "")
         |> Choice.bindSnd (fun _ -> Choice2Of2 "")
 

--- a/AAD.Test/AAD.Test.fsproj
+++ b/AAD.Test/AAD.Test.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>79a3edd0-2092-40a2-a04d-dcb46d5ca9ed</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>

--- a/AAD.Test/DomainTests.fs
+++ b/AAD.Test/DomainTests.fs
@@ -7,6 +7,11 @@ open AAD
 module DemandTests =
 
     [<Fact>]
+    let ``All when empty`` () =
+        All []
+        |> Demand.eval [] =! true
+
+    [<Fact>]
     let ``All when present`` () =
         All [Pattern ["A";"1"]; Pattern ["B";"2"]]
         |> Demand.eval [["A";"1"]; ["B";"2"]] =! true

--- a/AAD.Test/ResourceOwnerTests.fs
+++ b/AAD.Test/ResourceOwnerTests.fs
@@ -16,7 +16,7 @@ module Internals =
     module Introspection =
         let audience = ".default"
         let introspect = 
-              (TokenCache.mkDefault(), [Audience audience], oidcConfig)
+              (TokenCache.mkDefault(), [Audience audience], fun _ -> Async.result oidcConfig)
               |||> Introspector.mkNew 
         
         [<Fact>]

--- a/AAD.fs/YoLo.fs
+++ b/AAD.fs/YoLo.fs
@@ -328,25 +328,13 @@ module Option =
 type Base64String = string
 
 module String =
-  open System.Globalization // needed when using DNXCORE50
-  open System.IO
-  open System.Security.Cryptography
-
   /// Also, invariant culture
   let equals (a: string) (b: string) =
-#if DNXCORE50
-    (CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.None)).Equals(a, b)
-#else
     a.Equals(b, StringComparison.InvariantCulture)
-#endif
 
   /// Also, invariant culture
   let equalsCaseInsensitive (a: string) (b: string) =
-#if DNXCORE50
-    (CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase)).Equals(a, b)
-#else
     a.Equals(b, StringComparison.InvariantCultureIgnoreCase)
-#endif
     
   /// Compare ordinally with ignore case.
   let equalsOrdinalCI (str1: string) (str2: string) =
@@ -408,25 +396,13 @@ module Bytes =
     sha.ComputeHash ms
 
   let sha1 =
-#if DNXCORE50
-    hash (fun () -> SHA1.Create())
-#else
     hash (fun () -> new SHA1Managed())
-#endif
 
   let sha256 =
-#if DNXCORE50
-    hash (fun () -> SHA256.Create())
-#else
     hash (fun () -> new SHA256Managed())
-#endif
 
   let sha512 =
-#if DNXCORE50
-    hash (fun () -> SHA512.Create())
-#else
     hash (fun () -> new SHA512Managed())
-#endif
 
   let toHex (bs: byte[]) =
     BitConverter.ToString bs
@@ -801,11 +777,7 @@ module App =
 
   /// Gets the calling assembly's informational version number as a string
   let getVersion () =
-#if DNXCORE50
-    (typeof<Random>.GetTypeInfo().Assembly)
-#else
     Assembly.GetCallingAssembly()
-#endif
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             .InformationalVersion
 
@@ -824,11 +796,7 @@ module App =
 
   /// Get the current assembly resource
   let resource =
-#if DNXCORE50
-    let assembly = typeof<Random>.GetTypeInfo().Assembly
-#else
     let assembly = Assembly.GetExecutingAssembly ()
-#endif
     resourceIn assembly
 
 module Dictionary =

--- a/AAD.tasks.Test/AAD.tasks.Test.fsproj
+++ b/AAD.tasks.Test/AAD.tasks.Test.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>79a3edd0-2092-40a2-a04d-dcb46d5ca9ed</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The library ships as following packages:
 #### Building
 
 ##### Prerequisites
-The build requires at least .NET Core SDK 3 installed.
+The build requires at least .NET Core SDK 5 installed.
 When building for the first time restore the local tools, in this directory run:
 
 * `dotnet tool restore` to install [FAKE](https://fake.build/fake-gettingstarted.html), then

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 2.0.0
+
+* Breaking API change: load OIDC configuration on demand and refresh every 24h 
+
 ### 1.3.0
 
 * Breakup space-delimited claims into multiple entries

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ trigger:
 steps:
     - task: UseDotNet@2
       inputs:
-        version: '3.1.300'
+        version: '5.0.100'
 
     - task: DotNetCoreCLI@2
       displayName: "Restore tools"

--- a/docs/content/sample.fsx
+++ b/docs/content/sample.fsx
@@ -1,5 +1,5 @@
 (*** hide ***)
-#I "../../AAD.tasks.Test/bin/Debug/netcoreapp3.0"
+#I "../../AAD.tasks.Test/bin/Debug/net5.0"
 #r "TaskBuilder.fs.dll"
 #r "AAD.Giraffe.dll"
 #r "AAD.fs.tasks.dll"


### PR DESCRIPTION
Get OIDC config on demand, refresh it every 24h.

Users of `PartProtector.mkDefault` are unaffected, but the API changes in general are breaking.