### PR TITLE
Abstract away 'token'

### DIFF
--- a/AAD.Giraffe/Noop.fs
+++ b/AAD.Giraffe/Noop.fs
@@ -9,16 +9,17 @@ open AAD
 /// PartProtector implements no-op verification (it always succeeds) for PartProtector interface.
 [<RequireQualifiedAccess>]
 module PartProtector =
-    let token = JwtSecurityToken()
     /// Creates PartProtector instance.
-    let mkNew () =
-        { new PartProtector with 
-            member __.Verify (getDemand: HttpContext -> Task<Demand>) 
-                             (onSuccess: JwtSecurityToken -> HttpHandler) = 
+    let mkNew token =
+        { new PartProtector<'token> with 
+            member _.Verify (getDemand: HttpContext -> Task<Demand>) 
+                            (onSuccess: 'token -> HttpHandler) = 
                 onSuccess token
                 
-            member __.VerifyWith (getDemand: HttpContext -> Task<Demand>) 
-                                 (onSuccess: JwtSecurityToken -> HttpHandler)
-                                 (onError: JwtSecurityToken option -> WWWAuthenticate -> HttpHandler) = 
+            member _.VerifyWith (getDemand: HttpContext -> Task<Demand>) 
+                                (onSuccess: 'token -> HttpHandler)
+                                (onError: 'token option -> WWWAuthenticate -> HttpHandler) = 
                 onSuccess token
         }
+
+    let mkDefault () = JwtSecurityToken() |> mkNew

--- a/AAD.Suave/Noop.fs
+++ b/AAD.Suave/Noop.fs
@@ -2,23 +2,23 @@ namespace AAD.Noop
 
 
 open Suave
-open Suave.Operators
 open AAD
 open System.IdentityModel.Tokens.Jwt
 
 /// PartProtector implements no-op verification (it always succeeds) for PartProtector interface.
 [<RequireQualifiedAccess>]
 module PartProtector =
-    let token = JwtSecurityToken()
     /// Creates PartProtector instance.
-    let mkNew () =
-        { new PartProtector with 
+    let mkNew token =
+        { new PartProtector<'token> with 
             member __.Verify (getDemand: HttpContext -> Async<Demand>) 
-                             (onSuccess: JwtSecurityToken -> WebPart) = 
+                             (onSuccess: 'token -> WebPart) = 
                 onSuccess token
                 
             member __.VerifyWith (getDemand: HttpContext -> Async<Demand>) 
-                                 (onSuccess: JwtSecurityToken -> WebPart)
-                                 (onError: JwtSecurityToken option -> WWWAuthenticate -> WebPart) = 
+                                 (onSuccess: 'token -> WebPart)
+                                 (onError: 'token option -> WWWAuthenticate -> WebPart) = 
                 onSuccess token
         }
+
+    let mkDefault () = JwtSecurityToken()

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 6.0.0
+
+* Breaking: Generalized certain abstractions to make token validation fully pluggable.
+
 ### 5.0.0
 
 * Breaking: dependencies bump and net8.0 target


### PR DESCRIPTION
Internal requirements demand a private token validation implementation.
This PR generalizes the existing abstractions, while keeping the default token validation based on `JwtSecurityTokenHandler`. Other token representations and validation mechanisms are now fully pluggable via custom introspectors.

Integration tests succeed:
```
---------------------------------------------------------------------
Build Time Report
---------------------------------------------------------------------
Target        Duration
------        --------
clean         00:00:01.0963181
restore       00:00:04.1279632
build         00:00:12.8028750
test          00:00:18.1126286
integration   00:00:18.6896061
Total:        00:00:54.8870692
Status:       Ok
---------------------------------------------------------------------
```