### PR TITLE
reintroduce net6.0 target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ packages/
 output/
 tmp/
 *.user
+.env.local
 Directory.Build.props

--- a/AAD.Giraffe/AAD.Giraffe.fsproj
+++ b/AAD.Giraffe/AAD.Giraffe.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/AAD.Suave/AAD.Suave.fsproj
+++ b/AAD.Suave/AAD.Suave.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/AAD.Test/AAD.Test.fsproj
+++ b/AAD.Test/AAD.Test.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>79a3edd0-2092-40a2-a04d-dcb46d5ca9ed</UserSecretsId>
+    <NoWarn>3511</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="OpenIdConnectMetadata.json">

--- a/AAD.fs.tasks/AAD.fs.tasks.fsproj
+++ b/AAD.fs.tasks/AAD.fs.tasks.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants>TASKS</DefineConstants>
   </PropertyGroup>

--- a/AAD.fs/AAD.fs.fsproj
+++ b/AAD.fs/AAD.fs.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/AAD.tasks.Test/AAD.tasks.Test.fsproj
+++ b/AAD.tasks.Test/AAD.tasks.Test.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>79a3edd0-2092-40a2-a04d-dcb46d5ca9ed</UserSecretsId>
+    <NoWarn>3511</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="../AAD.Test/OpenIdConnectMetadata.json">

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 6.1.0
+* Reintroduce net6.0 target while keeping net8.0
+
 ### 6.0.0
 
 * Breaking: Generalized certain abstractions to make token validation fully pluggable.

--- a/build.fsx
+++ b/build.fsx
@@ -104,7 +104,7 @@ Target.create "restore" (fun _ ->
 
 Target.create "build" (fun _ ->
     let args = sprintf "/p:Version=%s --no-restore" ver.AsString
-    DotNet.publish (fun a -> a.WithCommon (fun c -> { c with CustomParams = Some args})) "."
+    DotNet.build (fun a -> a.WithCommon (fun c -> { c with CustomParams = Some args})) "."
 )
 
 Target.create "test" (fun _ ->


### PR DESCRIPTION
net8 SDK fixed native task CEs compilation and a couple of releases ago TaskBuilder dependency was removed in favour of native F# tasks support. 
This PR reintroduces the net6.0 target for backwards compatibility, while keeping the tooling on v8 SDK.