### PR TITLE
Convert public/Azure.AAD.fs to GitHub Actions

### DIFF
--- a/.github/workflows/azure.aad.fs.yml
+++ b/.github/workflows/azure.aad.fs.yml
@@ -1,0 +1,27 @@
+name: public/Azure.AAD.fs
+on:
+  push:
+    branches:
+    - master
+    - "*"
+  pull_request:
+    branches:
+    - master
+env:
+  BUILD_NUMBER: "$[counter('buildCounter',1)]"
+  NUGET_REPO_URL: https://api.nuget.org/v3/index.json
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-dotnet@v4.0.0
+      with:
+        dotnet-version: 8.0.100
+    - name: Restore tools
+      run: dotnet tool restore
+    - name: Build and publish
+      env:
+        NUGET_REPO_KEY: "${{ secrets.NUGET_REPO_KEY }}"
+      run: dotnet fsi


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/azure-fsharp-libs/public/_build?definitionId=1) :tada:

## Manual steps

Perform the following steps to complete the migration:

### public/Azure.AAD.fs
- [ ] Ensure secret is available: `${{ secrets.NUGET_REPO_KEY }}`