### PR TITLE
Fix tag push workflow trigger

### DIFF
--- a/.github/workflows/azure.aad.fs.yml
+++ b/.github/workflows/azure.aad.fs.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
     - master
-    - "refs/tags/*"
+    tags:
+    - '*'
   pull_request_target:
     branches:
     - master


### PR DESCRIPTION
## Summary
- Move the tag push pattern under `push.tags` so any tag creation starts the workflow.
- Keep `master` branch pushes triggering the existing CI path.

## Validation
- Ran `git diff --check -- .github/workflows/azure.aad.fs.yml`.
- Verified the PR branch is clean and pushed.

---
<sub>Session ID for resuming locally: `348cc0ae-abdb-491c-aa8c-328753ec0632`</sub>